### PR TITLE
Remove allow_all firewall rule from networks.tf

### DIFF
--- a/terraform/gcp/networks.tf
+++ b/terraform/gcp/networks.tf
@@ -16,12 +16,3 @@ resource "google_compute_subnetwork" "public-subnetwork" {
   }
 }
 
-resource "google_compute_firewall" "allow_all" {
-  name          = "terragoat-${var.environment}-firewall"
-  network       = google_compute_network.vpc.id
-  source_ranges = ["0.0.0.0/0"]
-  allow {
-    protocol = "tcp"
-    ports    = ["0-65535"]
-  }
-}


### PR DESCRIPTION
Removed the 'allow_all' firewall rule from the GCP network configuration.